### PR TITLE
Save snapshots to temporary directory

### DIFF
--- a/animate/animate.go
+++ b/animate/animate.go
@@ -15,7 +15,7 @@ import (
 
 // Animate makes a gif out of a series of png images available in imgDir. If loop
 // is true, the animation will loop infinitely, otherwise it'll do a single loop.
-func Animate(ctx context.Context, imgDir string, loop bool, delay int) error {
+func Animate(ctx context.Context, imgDir string, outDir string, loop bool, delay int) error {
 	files, _ := filepath.Glob(fmt.Sprintf("%s/*.png", imgDir))
 
 	outGif := &gif.GIF{}
@@ -43,7 +43,7 @@ func Animate(ctx context.Context, imgDir string, loop bool, delay int) error {
 		outGif.LoopCount = 0
 	}
 
-	outPath := fmt.Sprintf("%s/out.gif", imgDir)
+	outPath := fmt.Sprintf("%s/out.gif", outDir)
 	f, err := os.OpenFile(outPath, os.O_WRONLY|os.O_CREATE, 0o600)
 	if err != nil {
 		return err

--- a/animate/animate_test.go
+++ b/animate/animate_test.go
@@ -25,7 +25,7 @@ func TestAnimate(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(s *testing.T) {
-			err := Animate(context.TODO(), "testdata", c.loop, c.fps)
+			err := Animate(context.TODO(), "testdata", "testdata", c.loop, c.fps)
 			if err != nil {
 				t.Errorf("got unexpected error: %v", err)
 			}

--- a/config.go
+++ b/config.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"path"
 
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -12,7 +11,7 @@ import (
 type config struct {
 	durationSeconds     int
 	fps                 int
-	imgSaveDir          string
+	outputDir           string
 	initialSleepSeconds int
 	loop                bool
 	screen              int
@@ -22,11 +21,11 @@ type config struct {
 func getConfig() (c config, err error) {
 	v := viper.New()
 
-	flag.Int("durationSeconds", 4, "how many seconds long the animation should be")
+	flag.Int("durationSeconds", 3, "how many seconds long the animation should be")
 	flag.Int("fps", 10, "the frame rate the animation should be made in")
-	flag.String("imgSaveDir", "", "the absolute path to the directory where the output gif is to be stored")
-	flag.Int("initialSleepSeconds", 10, "the number of seconds to wait before taking the first snapshot")
+	flag.Int("initialSleepSeconds", 5, "the number of seconds to wait before taking the first snapshot")
 	flag.Bool("loop", true, "if the animation should loop indefinitely")
+	flag.String("outputDir", ".", "the absolute path to the directory where the output gif is to be stored")
 	flag.Int("screen", 0, "the number identifying the screen that should be captured, default is the main screen = 0")
 	flag.Int("timeOutMinutes", 5, "the number of minutes until the app is shut down as a safety measure")
 
@@ -40,15 +39,11 @@ func getConfig() (c config, err error) {
 	c = config{
 		durationSeconds:     v.GetInt(("durationSeconds")),
 		fps:                 v.GetInt("fps"),
-		imgSaveDir:          v.GetString("imgSaveDir"),
 		initialSleepSeconds: v.GetInt("initialSleepSeconds"),
 		loop:                v.GetBool("loop"),
+		outputDir:           v.GetString("outputDir"),
 		screen:              v.GetInt("screen"),
 		timeOutMinutes:      v.GetInt(("timeOutMinutes")),
-	}
-
-	if c.imgSaveDir != "" && !path.IsAbs(c.imgSaveDir) {
-		return c, fmt.Errorf("imgSaveDir must be an absolute path")
 	}
 
 	return c, nil


### PR DESCRIPTION
The app currently takes a flag/var with a directory where the temporary
images (screenshots) and the output gif is to be saved. This is error
prone as there could be other images in that directory and the glob
command is not using such a strict pattern. In addition, unrelated
images could be deleted.

* replace the mentioned flag with one called `outputDir` that is where
  the output gif file will be saved and defaults to the current
directory.

* create a temporary directory where to keep the snapshots.

* replace the cleaning up function that was looging for a pattern
  in the filenames in the img saving directory with one to delete the
temporary directory.

* reduce the default initial sleep seconds and animation duration.